### PR TITLE
fix: use absolute path for metada preview urls

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -53,7 +53,7 @@ export const metadata: Metadata = {
     description: 'Portfolio website of full stack developer João Carvalho.',
     images: [
       {
-        url: '/001.png',
+        url: `${siteUrl}/001.png`,
         width: 1200,
         height: 630,
         alt: 'João Carvalho',
@@ -64,7 +64,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'João Carvalho',
     description: 'Portfolio website of full stack developer João Carvalho.',
-    images: ['/001.png'],
+    images: [`${siteUrl}/001.png`],
   },
   robots: {
     index: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured social share preview images render reliably by using absolute URLs for Open Graph and Twitter metadata.
  * Prevents broken or missing thumbnails on social networks and chat apps across environments.
  * Uses the configured site URL when available; defaults to localhost in development.
  * No functional changes to the app; no user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->